### PR TITLE
Made react-easy-sort work out-of-the-box with items of variable size

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -166,24 +166,34 @@ const SortableList = <TTag extends keyof JSX.IntrinsicElements = typeof DEFAULT_
       lastTargetIndexRef.current = targetIndex
 
       const isMovingRight = sourceIndex < targetIndex
+      const draggedItemRects = itemsRect.current[sourceIndex]
+      const nextItemRects = itemsRect.current[isMovingRight ? sourceIndex + 1 : sourceIndex - 1]
+
+      if (nextItemRects === undefined) {
+        return
+      }
+
+      const spacingY = isMovingRight
+        ? (nextItemRects?.top ?? 0) - draggedItemRects.bottom
+        : draggedItemRects.top - (nextItemRects?.bottom ?? 0)
+
+      const spacingX = isMovingRight
+        ? (nextItemRects?.left ?? 0) - draggedItemRects.right
+        : draggedItemRects.left - (nextItemRects?.right ?? 0)
+
+      const translateX = (isMovingRight ? -1 : 1) * (draggedItemRects.width + spacingX)
+      const translateY = (isMovingRight ? -1 : 1) * (draggedItemRects.height + spacingY)
 
       // in this loop, we go over each sortable item and see if we need to update their position
       for (let index = 0; index < itemsRef.current.length; index += 1) {
         const currentItem = itemsRef.current[index]
-        const currentItemRect = itemsRect.current[index]
         // if current index is between sourceIndex and targetIndex, we need to translate them
         if (
           (isMovingRight && index >= sourceIndex && index <= targetIndex) ||
           (!isMovingRight && index >= targetIndex && index <= sourceIndex)
         ) {
-          // we need to move the item to the previous or next item position
-          const nextItemRects = itemsRect.current[isMovingRight ? index - 1 : index + 1]
-          if (nextItemRects) {
-            const translateX = nextItemRects.left - currentItemRect.left
-            const translateY = nextItemRects.top - currentItemRect.top
-            // we use `translate3d` to force using the GPU if available
-            currentItem.style.transform = `translate3d(${translateX}px, ${translateY}px, 0px)`
-          }
+          // we use `translate3d` to force using the GPU if available
+          currentItem.style.transform = `translate3d(${translateX}px, ${translateY}px, 0px)`
         }
         // otherwise, the item should be at its original position
         else {

--- a/stories/simple-horizontal-list/variable-width.stories.tsx
+++ b/stories/simple-horizontal-list/variable-width.stories.tsx
@@ -1,0 +1,104 @@
+import React from 'react'
+import arrayMove from 'array-move'
+
+import { action } from '@storybook/addon-actions'
+import { Story } from '@storybook/react'
+
+import SortableList, { SortableItem } from '../../src/index'
+import { generateItems } from '../helpers'
+import { makeStyles } from '@material-ui/core'
+
+export default {
+  component: SortableList,
+  title: 'react-easy-sort/Variable-width horizontal list',
+  parameters: {
+    componentSubtitle: 'SortableList',
+  },
+}
+
+const useStyles = makeStyles({
+  container: {
+    display: 'inline-block',
+    fontFamily: 'Helvetica, Arial, sans-serif',
+    userSelect: 'none',
+  },
+  listClassic: {
+    backgroundColor: 'rgb(170, 170, 240)',
+    padding: '0.25rem',
+  },
+  listFlex: {
+    backgroundColor: 'rgb(200, 200, 244)',
+    display: 'flex',
+    gap: 8,
+    padding: 8,
+  },
+  item: {
+    flexShrink: 0,
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'rgb(84, 84, 241)',
+    color: 'white',
+    height: 24,
+    cursor: 'grab',
+  },
+  dragged: {
+    backgroundColor: 'rgb(37, 37, 197)',
+  },
+})
+
+const widths = {
+  A: 120,
+  B: 30,
+  C: 60,
+  D: 90,
+}
+
+export const Demo: Story = () => {
+  const classes = useStyles()
+
+  const [items, setItems] = React.useState<string[]>(() => generateItems(4))
+
+  const onSortEnd = (oldIndex: number, newIndex: number) => {
+    action('onSortEnd')(`oldIndex=${oldIndex}, newIndex=${newIndex}`)
+    setItems((array) => arrayMove(array, oldIndex, newIndex))
+  }
+
+  return (
+    <div className={classes.container}>
+      <SortableList
+        onSortEnd={onSortEnd}
+        className={classes.listClassic}
+        draggedItemClassName={classes.dragged}
+      >
+        {items.map((item) => (
+          <SortableItem key={item}>
+            <div
+              className={classes.item}
+              style={{
+                width: widths[item],
+                margin: '0.25rem',
+                display: 'inline-flex',
+              }}
+            >
+              {item}
+            </div>
+          </SortableItem>
+        ))}
+      </SortableList>
+      <SortableList
+        onSortEnd={onSortEnd}
+        className={classes.listFlex}
+        draggedItemClassName={classes.dragged}
+      >
+        {items.map((item) => (
+          <SortableItem key={item}>
+            <div className={classes.item} style={{ width: widths[item] }}>
+              {item}
+            </div>
+          </SortableItem>
+        ))}
+      </SortableList>
+    </div>
+  )
+}

--- a/stories/simple-vertical-list/variable-height.stories.tsx
+++ b/stories/simple-vertical-list/variable-height.stories.tsx
@@ -1,0 +1,97 @@
+import React from 'react'
+import arrayMove from 'array-move'
+
+import { action } from '@storybook/addon-actions'
+import { Story } from '@storybook/react'
+
+import SortableList, { SortableItem } from '../../src/index'
+import { generateItems } from '../helpers'
+import { makeStyles } from '@material-ui/core'
+
+export default {
+  component: SortableList,
+  title: 'react-easy-sort/Variable-height vertical list',
+  parameters: {
+    componentSubtitle: 'SortableList',
+  },
+}
+
+const useStyles = makeStyles({
+  container: {
+    display: 'flex',
+    fontFamily: 'Helvetica, Arial, sans-serif',
+    userSelect: 'none',
+  },
+  listClassic: {
+    backgroundColor: 'rgb(170, 170, 240)',
+  },
+  listFlex: {
+    backgroundColor: 'rgb(200, 200, 244)',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 8,
+    padding: 8,
+  },
+  item: {
+    flexShrink: 0,
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'rgb(84, 84, 241)',
+    color: 'white',
+    width: 150,
+    cursor: 'grab',
+  },
+  dragged: {
+    backgroundColor: 'rgb(37, 37, 197)',
+  },
+})
+
+const heights = {
+  A: 120,
+  B: 30,
+  C: 60,
+  D: 90,
+}
+
+export const Demo: Story = () => {
+  const classes = useStyles()
+
+  const [items, setItems] = React.useState<string[]>(() => generateItems(4))
+
+  const onSortEnd = (oldIndex: number, newIndex: number) => {
+    action('onSortEnd')(`oldIndex=${oldIndex}, newIndex=${newIndex}`)
+    setItems((array) => arrayMove(array, oldIndex, newIndex))
+  }
+
+  return (
+    <div className={classes.container}>
+      <SortableList
+        onSortEnd={onSortEnd}
+        className={classes.listClassic}
+        draggedItemClassName={classes.dragged}
+      >
+        {items.map((item) => (
+          <SortableItem key={item}>
+            <div className={classes.item} style={{ height: heights[item], margin: '0.5rem' }}>
+              {item}
+            </div>
+          </SortableItem>
+        ))}
+      </SortableList>
+      <SortableList
+        onSortEnd={onSortEnd}
+        className={classes.listFlex}
+        draggedItemClassName={classes.dragged}
+      >
+        {items.map((item) => (
+          <SortableItem key={item}>
+            <div className={classes.item} style={{ height: heights[item] }}>
+              {item}
+            </div>
+          </SortableItem>
+        ))}
+      </SortableList>
+    </div>
+  )
+}


### PR DESCRIPTION
Closes #25


For reviewer's information: I haven't ran Prettier on the entire file of `src/index.tsx`, because that triggered some unrelated changes. I suggest maintainers to run Prettier on `src/index.tsx` after merge.

https://user-images.githubusercontent.com/4501047/150538621-7bd0173f-2da0-48b6-a48a-6ae71ae9abad.mov


