### PR TITLE
:sparkles: Added custom holder for dragged elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,14 @@ const App = () => {
 
 ### SortableList
 
-| Name                     |                   Description                    |                      Type                      | Default |
-| ------------------------ | :----------------------------------------------: | :--------------------------------------------: | ------: |
-| **as**                   |    Determines html tag for the container element     |         `keyof JSX.IntrinsicElements`          |   `div` |
-| **onSortEnd\***          | Called when the user finishes a sorting gesture. | `(oldIndex: number, newIndex: number) => void` |       - |
-| **draggedItemClassName** |     Class applied to the item being dragged      |                    `string`                    |       - |
-| **lockAxis**             |      Determines if an axis should be locked      |                 `'x'` or `'y'`                 |         |
-| **allowDrag**            |     Determines whether items can be dragged      |                   `boolean`                    |  `true` |
+| Name                     |                         Description                          |                      Type                      |         Default |
+| ------------------------ | :----------------------------------------------------------: | :--------------------------------------------: | --------------: |
+| **as**                   |        Determines html tag for the container element         |         `keyof JSX.IntrinsicElements`          |           `div` |
+| **onSortEnd\***          |       Called when the user finishes a sorting gesture.       | `(oldIndex: number, newIndex: number) => void` |               - |
+| **draggedItemClassName** |           Class applied to the item being dragged            |                    `string`                    |               - |
+| **lockAxis**             |            Determines if an axis should be locked            |                 `'x'` or `'y'`                 |                 |
+| **allowDrag**            |           Determines whether items can be dragged            |                   `boolean`                    |          `true` |
+| **customHolderRef**      | Ref of an element to use as a container for the dragged item |     `React.RefObject<HTMLElement \| null>`     | `document.body` |
 
 ### SortableItem
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,6 +19,8 @@ type Props<TTag extends keyof JSX.IntrinsicElements> = HTMLAttributes<TTag> & {
   as?: TTag
   /** Determines if an axis should be locked */
   lockAxis?: 'x' | 'y'
+  /** Reference to the Custom Holder element */
+  customHolderRef?: React.RefObject<HTMLElement | null>
 }
 
 // this context is only used so that SortableItems can register/remove themselves
@@ -38,6 +40,7 @@ const SortableList = <TTag extends keyof JSX.IntrinsicElements = typeof DEFAULT_
   draggedItemClassName,
   as,
   lockAxis,
+  customHolderRef,
   ...rest
 }: Props<TTag>) => {
   // this array contains the elements than can be sorted (wrapped inside SortableItem)
@@ -58,13 +61,14 @@ const SortableList = <TTag extends keyof JSX.IntrinsicElements = typeof DEFAULT_
   const offsetPointRef = React.useRef<Point>({ x: 0, y: 0 })
 
   React.useEffect(() => {
+    const holder = (customHolderRef?.current || document.body)
     return () => {
       // cleanup the target element from the DOM when SortableList in unmounted
       if (targetRef.current) {
-        document.body.removeChild(targetRef.current)
+        holder.removeChild(targetRef.current)
       }
     }
-  }, [])
+  }, [customHolderRef])
 
   const updateTargetPosition = (position: Point) => {
     if (targetRef.current && sourceIndexRef.current !== undefined) {
@@ -109,11 +113,12 @@ const SortableList = <TTag extends keyof JSX.IntrinsicElements = typeof DEFAULT_
         canvas.getContext('2d')?.drawImage(sourceCanvases[index], 0, 0)
       })
 
-      document.body.appendChild(copy)
+      const holder = (customHolderRef?.current || document.body)
+      holder.appendChild(copy)
 
       targetRef.current = copy
     },
-    [draggedItemClassName]
+    [customHolderRef, draggedItemClassName]
   )
 
   const listeners = useDrag({
@@ -242,7 +247,8 @@ const SortableList = <TTag extends keyof JSX.IntrinsicElements = typeof DEFAULT_
 
       // cleanup the target element from the DOM
       if (targetRef.current) {
-        document.body.removeChild(targetRef.current)
+        const holder = (customHolderRef?.current || document.body)
+        holder.removeChild(targetRef.current)
         targetRef.current = null
       }
     },


### PR DESCRIPTION
Added the ability to pass an element reference to `SortableList` to be used as a temporary container for dragged elements instead of using `body`.

When using CSS or SASS is very common to define component styles as children of some container, so when the dragged component gets moved to `body` all the styles get disabled.
```sass
// styles.scss
form {
  width: 100px;
  input {
    background: black;
    color: white;
    width: 50%;
  }
}
```
```jsx
// MyComponent.(jsx|tsx)
const MyComponent = () => {
  const customHolderRef = useRef()

  return (
    <form>
      <div className="custom-holder" ref={customHolderRef} />
      <SortableList customHolderRef={customHolderRef} {...props}>
        {items.map((item) => (
          <SortableItem key={item}>
            <input type="text" value={item} />
          </SortableItem>
        ))}
      </SortableList>
    </form>
  )
}
```

This way the holder element for the dragged components can be located inside the same parent component as `SortableList` and keep all styles intact.