### PR TITLE
Add `allowDrag` prop support for touch devices

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -217,7 +217,7 @@ export const useDrag = ({
     if (isTouchDevice) {
       const container = containerRef.current
 
-      if (!allowDrag) {
+      if (allowDrag) {
         container?.addEventListener('touchstart', onTouchStart, { capture: true, passive: false })
         // we are adding this touchmove listener to cancel drag if user is scrolling
         // however, it's also important to have a touchmove listener always set

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -231,6 +231,10 @@ export const useDrag = ({
           capture: false,
           passive: false,
         })
+      } else {
+        container?.removeEventListener('touchstart', onTouchStart, { capture: true })
+        document.removeEventListener('touchmove', touchScrollListener, { capture: false })
+        document.removeEventListener('touchend', touchScrollListener, { capture: false })
       }
 
       return () => {

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -231,16 +231,12 @@ export const useDrag = ({
           capture: false,
           passive: false,
         })
-      } else {
-        container?.removeEventListener('touchstart', onTouchStart, { capture: true })
-        document.removeEventListener('touchmove', touchScrollListener, { capture: false })
-        document.removeEventListener('touchend', touchScrollListener, { capture: false })
       }
 
       return () => {
-        container?.removeEventListener('touchstart', onTouchStart)
-        document.removeEventListener('touchmove', touchScrollListener)
-        document.removeEventListener('touchend', touchScrollListener)
+        container?.removeEventListener('touchstart', onTouchStart, { capture: true })
+        document.removeEventListener('touchmove', touchScrollListener, { capture: false })
+        document.removeEventListener('touchend', touchScrollListener, { capture: false })
         document.removeEventListener('touchmove', onTouchMove)
         document.removeEventListener('touchend', onTouchEnd)
         enableContextMenu()

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -38,11 +38,19 @@ type UseDragProps = {
   onStart?: (args: OnStartArgs) => void
   onMove?: (args: OnMoveArgs) => void
   onEnd?: () => void
+  allowDrag?: boolean
   containerRef: React.MutableRefObject<HTMLElement | null>
   knobs?: HTMLElement[]
 }
 
-export const useDrag = ({ onStart, onMove, onEnd, containerRef, knobs }: UseDragProps) => {
+export const useDrag = ({
+  onStart,
+  onMove,
+  onEnd,
+  allowDrag = true,
+  containerRef,
+  knobs,
+}: UseDragProps) => {
   // contains the top-left coordinates of the container in the window. Set on drag start and used in drag move
   const containerPositionRef = React.useRef<Point>({ x: 0, y: 0 })
   // on touch devices, we only start the drag gesture after pressing the item 200ms.
@@ -208,19 +216,22 @@ export const useDrag = ({ onStart, onMove, onEnd, containerRef, knobs }: UseDrag
   React.useLayoutEffect(() => {
     if (isTouchDevice) {
       const container = containerRef.current
-      container?.addEventListener('touchstart', onTouchStart, { capture: true, passive: false })
-      // we are adding this touchmove listener to cancel drag if user is scrolling
-      // however, it's also important to have a touchmove listener always set
-      // with non-capture and non-passive option to prevent an issue on Safari
-      // with e.preventDefault (https://github.com/atlassian/react-beautiful-dnd/issues/1374)
-      document.addEventListener('touchmove', touchScrollListener, {
-        capture: false,
-        passive: false,
-      })
-      document.addEventListener('touchend', touchScrollListener, {
-        capture: false,
-        passive: false,
-      })
+
+      if (!allowDrag) {
+        container?.addEventListener('touchstart', onTouchStart, { capture: true, passive: false })
+        // we are adding this touchmove listener to cancel drag if user is scrolling
+        // however, it's also important to have a touchmove listener always set
+        // with non-capture and non-passive option to prevent an issue on Safari
+        // with e.preventDefault (https://github.com/atlassian/react-beautiful-dnd/issues/1374)
+        document.addEventListener('touchmove', touchScrollListener, {
+          capture: false,
+          passive: false,
+        })
+        document.addEventListener('touchend', touchScrollListener, {
+          capture: false,
+          passive: false,
+        })
+      }
 
       return () => {
         container?.removeEventListener('touchstart', onTouchStart)
@@ -241,6 +252,7 @@ export const useDrag = ({ onStart, onMove, onEnd, containerRef, knobs }: UseDrag
     }
   }, [
     isTouchDevice,
+    allowDrag,
     detectTouchDevice,
     onMouseMove,
     onTouchMove,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -61,7 +61,7 @@ const SortableList = <TTag extends keyof JSX.IntrinsicElements = typeof DEFAULT_
   const offsetPointRef = React.useRef<Point>({ x: 0, y: 0 })
 
   React.useEffect(() => {
-    const holder = (customHolderRef?.current || document.body)
+    const holder = customHolderRef?.current || document.body
     return () => {
       // cleanup the target element from the DOM when SortableList in unmounted
       if (targetRef.current) {
@@ -113,7 +113,7 @@ const SortableList = <TTag extends keyof JSX.IntrinsicElements = typeof DEFAULT_
         canvas.getContext('2d')?.drawImage(sourceCanvases[index], 0, 0)
       })
 
-      const holder = (customHolderRef?.current || document.body)
+      const holder = customHolderRef?.current || document.body
       holder.appendChild(copy)
 
       targetRef.current = copy
@@ -122,6 +122,7 @@ const SortableList = <TTag extends keyof JSX.IntrinsicElements = typeof DEFAULT_
   )
 
   const listeners = useDrag({
+    allowDrag,
     containerRef,
     knobs: knobs.current,
     onStart: ({ pointInWindow }) => {
@@ -247,7 +248,7 @@ const SortableList = <TTag extends keyof JSX.IntrinsicElements = typeof DEFAULT_
 
       // cleanup the target element from the DOM
       if (targetRef.current) {
-        const holder = (customHolderRef?.current || document.body)
+        const holder = customHolderRef?.current || document.body
         holder.removeChild(targetRef.current)
         targetRef.current = null
       }


### PR DESCRIPTION
Add `allowDrag` prop support for touch (mobile) devices.

I was able to test this locally and it seems to be working well. 