### PR TITLE
Fix createPackageFile:exports

### DIFF
--- a/scripts/copy-build-files.js
+++ b/scripts/copy-build-files.js
@@ -23,9 +23,9 @@ async function createPackageFile() {
     module: './index.module.js',
     'jsnext:main': './index.module.js',
     'react-native': './index.module.js',
-    types: './index.d.ts',
     exports: {
       '.': {
+        types: "./index.d.ts",
         import: './index.module.js',
         require: './index.js',
       },


### PR DESCRIPTION
The ```types``` field is no longer support if there's an ```exports``` field in ```package.json```. So I updated ```createPackageFile``` function in ```copy-build-files.js``` file. Currently ```typescript is not supporting``` this package. If you merge it it works.